### PR TITLE
feat(encryption): AES EncryptionType Enum

### DIFF
--- a/cfgparser_core/Cargo.toml
+++ b/cfgparser_core/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "staticlib", "lib"]
 
+[features]
+default = ["cfgparser_encryption/aes"]
+
 [dependencies]
 base64 = "0.22.1"
 cfgparser_encryption = { path = "../cfgparser_encryption" }

--- a/cfgparser_core/src/lib.rs
+++ b/cfgparser_core/src/lib.rs
@@ -231,6 +231,13 @@ pub extern "C" fn read_cfg_with_encryption(
                 Err(_) => return std::ptr::null(),
             };
         read_result = read_self(decryptor);
+    } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
+        let decryptor: cfgparser_encryption::aes::engine::AESCipher =
+            match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
+                Ok(aesc) => aesc,
+                Err(_) => return std::ptr::null(),
+            };
+        read_result = read_self(decryptor);
     } else {
         read_result = Err("invalid encryption type".into());
     }

--- a/cfgparser_core/src/lib.rs
+++ b/cfgparser_core/src/lib.rs
@@ -327,6 +327,13 @@ pub extern "C" fn read_cfg_from_file_with_encryption(
                 Err(_) => return std::ptr::null(),
             };
         read_result = read_from_file(filename.to_string(), decryptor);
+    } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
+        let decryptor: cfgparser_encryption::aes::engine::AESCipher =
+            match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
+                Ok(aesc) => aesc,
+                Err(_) => return std::ptr::null(),
+            };
+        read_result = read_from_file(filename.to_string(), decryptor);
     } else {
         read_result = Err("invalid encryption type".into());
     }

--- a/cfgparser_encryption/src/lib.rs
+++ b/cfgparser_encryption/src/lib.rs
@@ -15,6 +15,7 @@ pub enum EncryptionType {
     #[default]
     Xor,
     Viginere,
+    Aes,
 }
 
 /// generic trait designed to describe a structure that can decrypt


### PR DESCRIPTION
## Description

Added AES to the `EncryptionType` enum in `cfgparser_encryption`. Also updated the two C functions that allow the user to specify an encryption type and added a block for an AES decryptor.

## Testing

- Ran unit tests to confirm expected behavior.
- Compiled lib and ran C Proof Of Concept program.

## Associated Issues

#41 : Add AES To EncryptionType Enum