### PR TITLE
feat(encryption): AES Encryption

### DIFF
--- a/cfgparser_core/Cargo.toml
+++ b/cfgparser_core/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "staticlib", "lib"]
 
+[features]
+default = ["cfgparser_encryption/aes"]
+
 [dependencies]
 base64 = "0.22.1"
 cfgparser_encryption = { path = "../cfgparser_encryption" }

--- a/cfgparser_core/src/lib.rs
+++ b/cfgparser_core/src/lib.rs
@@ -231,6 +231,13 @@ pub extern "C" fn read_cfg_with_encryption(
                 Err(_) => return std::ptr::null(),
             };
         read_result = read_self(decryptor);
+    } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
+        let decryptor: cfgparser_encryption::aes::engine::AESCipher =
+            match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
+                Ok(aesc) => aesc,
+                Err(_) => return std::ptr::null(),
+            };
+        read_result = read_self(decryptor);
     } else {
         read_result = Err("invalid encryption type".into());
     }
@@ -324,6 +331,13 @@ pub extern "C" fn read_cfg_from_file_with_encryption(
         let decryptor: cfgparser_encryption::viginere::engine::ViginereCipher =
             match cfgparser_encryption::viginere::engine::ViginereCipher::new(key.to_vec()) {
                 Ok(vc) => vc,
+                Err(_) => return std::ptr::null(),
+            };
+        read_result = read_from_file(filename.to_string(), decryptor);
+    } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
+        let decryptor: cfgparser_encryption::aes::engine::AESCipher =
+            match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
+                Ok(aesc) => aesc,
                 Err(_) => return std::ptr::null(),
             };
         read_result = read_from_file(filename.to_string(), decryptor);

--- a/cfgparser_encryption/Cargo.toml
+++ b/cfgparser_encryption/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 crate-type = ["lib"]
 
 [features]
-default = ["aes"]
 aes = []
 
 [dependencies]

--- a/cfgparser_encryption/Cargo.toml
+++ b/cfgparser_encryption/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["lib"]
 
+[features]
+default = ["aes"]
+aes = []
+
 [dependencies]
+aes-gcm = "0.10.3"

--- a/cfgparser_encryption/src/aes.rs
+++ b/cfgparser_encryption/src/aes.rs
@@ -1,0 +1,4 @@
+//! module designed to implement an AES encryptor/decryptor
+//! that is in compliance with the cfgparser library.
+
+pub mod engine;

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,7 +1,4 @@
-use aes_gcm::{
-    aead::{Aead, KeyInit},
-    Aes256Gcm, Key, Nonce,
-};
+use aes_gcm::aead::{Aead, KeyInit};
 
 #[derive(Debug)]
 pub enum AESError {
@@ -45,12 +42,12 @@ impl crate::Decryptor for AESCipher {
         let key: &aes_gcm::Key<aes_gcm::Aes256Gcm> =
             aes_gcm::Key::<aes_gcm::Aes256Gcm>::from_slice(&self.key);
 
-        // split the encrypted data into nonce and ciphertext. this
+        // split the encrypted data into nonce and cipherbytes. this
         // will extract the nonce that will be used to decrypt the data
-        // and the ciphertext that will be decrypted.
+        // and the cipherbytes that will be decrypted.
         //
         // bytes 0 -> 11: nonce
-        // bytes 12 -> n: ciphertext
+        // bytes 12 -> n: cipherbytes
         let (nonce_arr, cipherbytes) = ciphertext.split_at(12);
 
         // rebuild the nonce using the bytes extracted from the

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,4 +1,4 @@
-use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::aead::{Aead, AeadCore, KeyInit};
 
 #[derive(Debug)]
 pub enum AESError {
@@ -58,6 +58,32 @@ impl crate::Decryptor for AESCipher {
 
         match aescipher.decrypt(nonce, cipherbytes) {
             Ok(plaintext) => Ok(plaintext),
+            Err(e) => Err(e.to_string().into()),
+        }
+    }
+}
+
+impl crate::Encryptor for AESCipher {
+    fn encrypt(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let key: &aes_gcm::Key<aes_gcm::Aes256Gcm> =
+            aes_gcm::Key::<aes_gcm::Aes256Gcm>::from_slice(&self.key);
+
+        // generate a random, 12 byte nonce to use during encryption.
+        let nonce = aes_gcm::Aes256Gcm::generate_nonce(&mut aes_gcm::aead::OsRng);
+
+        // create a new AES cipher object using the encryption key.
+        let aescipher = aes_gcm::Aes256Gcm::new(key);
+
+        match aescipher.encrypt(&nonce, &plaintext[..]) {
+            Ok(enc_result) => {
+                // return a slice with the first 12 bytes being the
+                // nonce and the remaining bytes being the encrypted
+                // message. this allows the receiver to extract the
+                // nonce from the message during decryption.
+                let mut ciphertext: Vec<u8> = nonce.to_vec();
+                ciphertext.extend_from_slice(&enc_result);
+                Ok(ciphertext)
+            }
             Err(e) => Err(e.to_string().into()),
         }
     }

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -49,6 +49,14 @@ impl AESCipher {
         validate_key(key.clone())?;
         Ok(AESCipher { key })
     }
+
+    /// function designed to update the key used for encryption
+    /// and decryption by the AESCipher.
+    pub fn update_key(&mut self, key: Vec<u8>) -> Result<(), AESError> {
+        validate_key(key.clone())?;
+        self.key = key;
+        Ok(())
+    }
 }
 
 impl crate::Decryptor for AESCipher {

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,9 +1,13 @@
+use aes_gcm::KeyInit;
+
 #[derive(Debug)]
 pub enum AESError {
     KeyLength(String),
 }
 
 const ERR_KEY_LEN: &str = "invalid key length. must be 16, 24 or 32 bytes";
+const ERR_128: &str = "AES-128 is not currently supported";
+const ERR_192: &str = "AES-192 is not currently supported";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AESCipher {
@@ -19,12 +23,26 @@ fn validate_key(key: Vec<u8>) -> Result<(), AESError> {
         return Err(AESError::KeyLength(ERR_KEY_LEN.to_string()));
     }
 
-    Ok(())
+    match key_size {
+        16 => Err(AESError::KeyLength(ERR_128.to_string())),
+        24 => Err(AESError::KeyLength(ERR_192.to_string())),
+        _ => Ok(()),
+    }
 }
 
 impl AESCipher {
     pub fn new(key: Vec<u8>) -> Result<AESCipher, AESError> {
         validate_key(key.clone())?;
         Ok(AESCipher { key })
+    }
+}
+
+impl crate::Decryptor for AESCipher {
+    fn decrypt(&self, ciphertext: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+        let key: &aes_gcm::Key<aes_gcm::Aes256Gcm> =
+            aes_gcm::Key::<aes_gcm::Aes256Gcm>::from_slice(&self.key);
+        let cipher: aes_gcm::Aes256Gcm = aes_gcm::Aes256Gcm::new(key);
+
+        Ok(vec![])
     }
 }

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,6 +1,9 @@
 use aes_gcm::aead::{Aead, AeadCore, KeyInit};
 
-#[derive(Debug)]
+#[cfg(test)]
+mod unit_tests;
+
+#[derive(Debug, PartialEq, Eq)]
 pub enum AESError {
     KeyLength(String),
 }

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,0 +1,4 @@
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AESCipher {
+    key: Vec<u8>,
+}

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,4 +1,7 @@
-use aes_gcm::KeyInit;
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Key, Nonce,
+};
 
 #[derive(Debug)]
 pub enum AESError {
@@ -41,8 +44,24 @@ impl crate::Decryptor for AESCipher {
     fn decrypt(&self, ciphertext: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let key: &aes_gcm::Key<aes_gcm::Aes256Gcm> =
             aes_gcm::Key::<aes_gcm::Aes256Gcm>::from_slice(&self.key);
-        let cipher: aes_gcm::Aes256Gcm = aes_gcm::Aes256Gcm::new(key);
 
-        Ok(vec![])
+        // split the encrypted data into nonce and ciphertext. this
+        // will extract the nonce that will be used to decrypt the data
+        // and the ciphertext that will be decrypted.
+        //
+        // bytes 0 -> 11: nonce
+        // bytes 12 -> n: ciphertext
+        let (nonce_arr, cipherbytes) = ciphertext.split_at(12);
+
+        // rebuild the nonce using the bytes extracted from the
+        // encrypted data above.
+        let nonce = aes_gcm::Nonce::from_slice(nonce_arr);
+
+        let aescipher = aes_gcm::Aes256Gcm::new(key);
+
+        match aescipher.decrypt(nonce, cipherbytes) {
+            Ok(plaintext) => Ok(plaintext),
+            Err(e) => Err(e.to_string().into()),
+        }
     }
 }

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -5,6 +5,14 @@ pub enum AESError {
     KeyLength(String),
 }
 
+impl ToString for AESError {
+    fn to_string(&self) -> String {
+        match self {
+            AESError::KeyLength(s) => s.to_string(),
+        }
+    }
+}
+
 const ERR_KEY_LEN: &str = "invalid key length. must be 16, 24 or 32 bytes";
 const ERR_128: &str = "AES-128 is not currently supported";
 const ERR_192: &str = "AES-192 is not currently supported";

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -1,15 +1,29 @@
+#[derive(Debug)]
+pub enum AESError {
+    KeyLength(String),
+}
+
+const ERR_KEY_LEN: &str = "invalid key length. must be 16, 24 or 32 bytes";
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AESCipher {
     key: Vec<u8>,
 }
 
 /// function designed to check whether a given AES key is valid.
-fn validate_key(key: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+fn validate_key(key: Vec<u8>) -> Result<(), AESError> {
+    let valid_lengths: Vec<usize> = vec![16, 24, 32];
+    let key_size: usize = key.len();
+
+    if !valid_lengths.contains(&key_size) {
+        return Err(AESError::KeyLength(ERR_KEY_LEN.to_string()));
+    }
+
     Ok(())
 }
 
 impl AESCipher {
-    pub fn new(key: Vec<u8>) -> Result<AESCipher, Box<dyn std::error::Error>> {
+    pub fn new(key: Vec<u8>) -> Result<AESCipher, AESError> {
         validate_key(key.clone())?;
         Ok(AESCipher { key })
     }

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -2,3 +2,15 @@
 pub struct AESCipher {
     key: Vec<u8>,
 }
+
+/// function designed to check whether a given AES key is valid.
+fn validate_key(key: Vec<u8>) -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+impl AESCipher {
+    pub fn new(key: Vec<u8>) -> Result<AESCipher, Box<dyn std::error::Error>> {
+        validate_key(key.clone())?;
+        Ok(AESCipher { key })
+    }
+}

--- a/cfgparser_encryption/src/aes/engine.rs
+++ b/cfgparser_encryption/src/aes/engine.rs
@@ -17,6 +17,9 @@ const ERR_KEY_LEN: &str = "invalid key length. must be 16, 24 or 32 bytes";
 const ERR_128: &str = "AES-128 is not currently supported";
 const ERR_192: &str = "AES-192 is not currently supported";
 
+/// expected size of the nonce when decrypting.
+pub const NONCE_SIZE: usize = 12;
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AESCipher {
     key: Vec<u8>,
@@ -56,7 +59,7 @@ impl crate::Decryptor for AESCipher {
         //
         // bytes 0 -> 11: nonce
         // bytes 12 -> n: cipherbytes
-        let (nonce_arr, cipherbytes) = ciphertext.split_at(12);
+        let (nonce_arr, cipherbytes) = ciphertext.split_at(NONCE_SIZE);
 
         // rebuild the nonce using the bytes extracted from the
         // encrypted data above.

--- a/cfgparser_encryption/src/aes/engine/unit_tests.rs
+++ b/cfgparser_encryption/src/aes/engine/unit_tests.rs
@@ -1,0 +1,76 @@
+use crate::{Decryptor, Encryptor};
+
+use super::*;
+
+#[test]
+/// test designed to confirm the decrypt functionality of the
+/// AESCipher is working as expected.
+fn test_decrypt() -> Result<(), Box<dyn std::error::Error>> {
+    let ciphertext: Vec<u8> = vec![
+        66, 168, 189, 189, 234, 64, 241, 80, 19, 32, 71, 136, 110, 231, 230, 187, 172, 117, 86,
+        127, 195, 68, 233, 166, 8, 215, 110, 4, 78, 29, 108, 177, 149, 241, 185, 183, 191, 78, 205,
+        233, 246, 77, 10, 158,
+    ];
+
+    let key: Vec<u8> = vec![
+        57, 72, 60, 6, 7, 247, 134, 240, 254, 56, 39, 120, 58, 56, 12, 209, 39, 26, 66, 154, 78,
+        38, 106, 196, 105, 68, 79, 66, 220, 128, 101, 177,
+    ];
+
+    let expected: Vec<u8> = b"this is a secret".to_vec();
+    let cipher: AESCipher = match AESCipher::new(key) {
+        Ok(c) => c,
+        Err(e) => return Err(e.to_string().into()),
+    };
+
+    let plaintext: Vec<u8> = cipher.decrypt(ciphertext)?;
+
+    assert_eq!(plaintext, expected);
+
+    Ok(())
+}
+
+#[test]
+/// test designed to confirm the encrypt functionality of the
+/// AESCipher is working as expected.
+///
+/// because the nonce is randomly generate each time, the test
+/// is conducted by encrypting a known string and confirming
+/// the decrypted result of the `encrypt()` function resolved to
+/// the original plaintext.
+fn test_encrypt() -> Result<(), Box<dyn std::error::Error>> {
+    let key: Vec<u8> = vec![
+        57, 72, 60, 6, 7, 247, 134, 240, 254, 56, 39, 120, 58, 56, 12, 209, 39, 26, 66, 154, 78,
+        38, 106, 196, 105, 68, 79, 66, 220, 128, 101, 177,
+    ];
+    let cipher: AESCipher = match AESCipher::new(key) {
+        Ok(c) => c,
+        Err(e) => return Err(e.to_string().into()),
+    };
+    let plaintext: Vec<u8> = b"this is a secret".to_vec();
+
+    let result: Vec<u8> = cipher.decrypt(cipher.encrypt(plaintext.clone())?)?;
+
+    assert_eq!(result, plaintext);
+
+    Ok(())
+}
+
+#[test]
+/// test designed to confirm the key validation logic works
+/// as expected.
+fn test_validate_key() -> Result<(), AESError> {
+    let test_key_1: Vec<u8> = vec![
+        116, 104, 105, 115, 32, 105, 115, 32, 97, 110, 32, 105, 110, 118, 97, 108, 105, 100, 32,
+        107, 101, 121,
+    ];
+    let test_key_2: Vec<u8> = vec![
+        57, 72, 60, 6, 7, 247, 134, 240, 254, 56, 39, 120, 58, 56, 12, 209, 39, 26, 66, 154, 78,
+        38, 106, 196, 105, 68, 79, 66, 220, 128, 101, 177,
+    ];
+
+    assert!(validate_key(test_key_1).is_err());
+    assert!(validate_key(test_key_2).is_ok());
+
+    Ok(())
+}

--- a/cfgparser_encryption/src/lib.rs
+++ b/cfgparser_encryption/src/lib.rs
@@ -3,6 +3,7 @@
 //! this is designed to be used by cfgparser_core for its main functionality
 //! and obfuscation.
 
+pub mod aes;
 pub mod viginere;
 pub mod xor;
 

--- a/cfgparser_encryption/src/lib.rs
+++ b/cfgparser_encryption/src/lib.rs
@@ -15,6 +15,7 @@ pub enum EncryptionType {
     #[default]
     Xor,
     Viginere,
+    Aes,
 }
 
 /// generic trait designed to describe a structure that can decrypt

--- a/cfgparser_encryption/src/lib.rs
+++ b/cfgparser_encryption/src/lib.rs
@@ -3,6 +3,7 @@
 //! this is designed to be used by cfgparser_core for its main functionality
 //! and obfuscation.
 
+#[cfg(feature = "aes")]
 pub mod aes;
 pub mod viginere;
 pub mod xor;


### PR DESCRIPTION
## Description

Added an `aes` module to `cfgparser_encryption`. This includes unit tests to confirm the `Encryptor` and `Decryptor` operate as expected. The `aes` module has been marked as an optional feature in `cfgparser_encryption` but is marked as a `default` module in `cfgparser_core` to support `aes` usage in the C functions.

Additionally, AES has been added to the `EncryptionType` enum defined in the `cfgparser_encryption` library.

## Testing

- Ran unit tests to confirm everything working as expected.
- Compiled shared object and ran C Proof Of Concept program to confirm everything working.

## Associated Issues

#26 : AES Encryption
#27 : AES Unit Test
#41 : AES EncryptionType Enum