### PR TITLE
feat(helpers): C Header - Initial

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cfgparser-so-${{ github.ref_name }}
-          path: target/release/libcfgparser_core.so
+          path: |
+            helpers/c/cfgparser.h
+            helpers/c/install.sh
+            target/release/libcfgparser_core.so
 
   build_windows:
     runs-on: windows-latest

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -1,0 +1,42 @@
+#ifndef __CFGPARSER_H
+#define __CFGPARSER_H
+
+/*
+function designed to read the end of the current binary and
+extract configuration information from it. this will return
+the C2 address in the form "<scheme>://<ip>:<port>".
+
+the extracted bytes are XOR-decrypted and base64-decoded before
+being JSON deserialized into a configuration struct. the information
+in this struct is then used to build the string that gets
+returned by the function.
+
+note: if the key passed in is NULL, a default of 'q' will be used
+when attempting to decrypt the bytes.
+*/
+extern char *read_cfg(char *key);
+
+/*
+function designed to read the end of a target file and
+extract configuration information from it. this will return
+the C2 address in the form "<scheme>://<ip>:<port>".
+
+the extracted bytes are XOR-decrypted and base64-decoded before
+being JSON deserialized into a configuration struct. the information
+in this struct is then used to build the string that gets
+returned by the function.
+
+note: if the key passed in is NULL, a default of 'q' will be used
+when attempting to decrypt the bytes.
+*/
+extern char *read_cfg_from_file(char *filename, char *key);
+
+/*
+function designed to free memory that was originally allocated
+by rust. since the pointer was created by the rust library, the
+rust library still owns that memory and, therefore, must be freed
+by the library.
+*/
+extern void free_memory(char *ptr);
+
+#endif // __CFGPARSER_H

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -1,9 +1,15 @@
 #ifndef __CFGPARSER_H
 #define __CFGPARSER_H
 
-#define ENCTYPE_XOR 0
-#define ENCTYPE_VIGINERE 1
-#define ENCTYPE_AES 2
+/*
+enum mimicing the EncType enum defined in the rust module.
+*/
+enum EncyptionType
+{
+    Xor,
+    Viginere,
+    Aes,
+};
 
 #ifdef __cplusplus
 extern "C"

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -43,7 +43,7 @@ extern "C"
 
     the type of encryption is specified by the "enc_type" argument.
     */
-    extern char *read_cfg_with_encryption(char *key, int enc_type);
+    extern char *read_cfg_with_encryption(char *key, EncyptionType enc_type);
 
     /*
     function designed to read the end of a target file and
@@ -72,7 +72,7 @@ extern "C"
 
     the type of encryption is specified by the "enc_type" argument.
     */
-    extern char *read_cfg_from_file_with_encryption(char *filename, char *key, int enc_type);
+    extern char *read_cfg_from_file_with_encryption(char *filename, char *key, EncyptionType enc_type);
 
     /*
     function designed to free memory that was originally allocated

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -17,6 +17,20 @@ when attempting to decrypt the bytes.
 extern char *read_cfg(char *key);
 
 /*
+function designed to read the end of the current binary and
+extract configuration information from it. this will return
+the C2 address in the form "<scheme>://<ip>:<port>".
+
+the extracted bytes are decrypted and base64-decoded before
+being JSON deserialized into a configuration struct. the information
+in this struct is then used to build the string that gets
+returned by the function.
+
+the type of encryption is specified by the "enc_type" argument.
+*/
+extern char *read_cfg_with_encryption(char *key, int enc_type);
+
+/*
 function designed to read the end of a target file and
 extract configuration information from it. this will return
 the C2 address in the form "<scheme>://<ip>:<port>".
@@ -30,6 +44,20 @@ note: if the key passed in is NULL, a default of 'q' will be used
 when attempting to decrypt the bytes.
 */
 extern char *read_cfg_from_file(char *filename, char *key);
+
+/*
+function designed to read the end of a target file and
+extract configuration information from it. this will return
+the C2 address in the form "<scheme>://<ip>:<port>".
+
+the extracted bytes are decrypted and base64-decoded before
+being JSON deserialized into a configuration struct. the information
+in this struct is then used to build the string that gets
+returned by the function.
+
+the type of encryption is specified by the "enc_type" argument.
+*/
+extern char *read_cfg_from_file_with_encryption(char *filename, char *key, int enc_type);
 
 /*
 function designed to free memory that was originally allocated

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -1,6 +1,10 @@
 #ifndef __CFGPARSER_H
 #define __CFGPARSER_H
 
+#define ENCTYPE_XOR 0
+#define ENCTYPE_VIGINERE 1
+#define ENCTYPE_AES 2
+
 /*
 function designed to read the end of the current binary and
 extract configuration information from it. this will return

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -2,7 +2,7 @@
 #define __CFGPARSER_H
 
 /*
-enum mimicing the EncType enum defined in the rust module.
+enum mimicing the EncryptionType enum defined in the rust module.
 */
 enum EncyptionType
 {

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -5,70 +5,79 @@
 #define ENCTYPE_VIGINERE 1
 #define ENCTYPE_AES 2
 
-/*
-function designed to read the end of the current binary and
-extract configuration information from it. this will return
-the C2 address in the form "<scheme>://<ip>:<port>".
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
-the extracted bytes are XOR-decrypted and base64-decoded before
-being JSON deserialized into a configuration struct. the information
-in this struct is then used to build the string that gets
-returned by the function.
+    /*
+    function designed to read the end of the current binary and
+    extract configuration information from it. this will return
+    the C2 address in the form "<scheme>://<ip>:<port>".
 
-note: if the key passed in is NULL, a default of 'q' will be used
-when attempting to decrypt the bytes.
-*/
-extern char *read_cfg(char *key);
+    the extracted bytes are XOR-decrypted and base64-decoded before
+    being JSON deserialized into a configuration struct. the information
+    in this struct is then used to build the string that gets
+    returned by the function.
 
-/*
-function designed to read the end of the current binary and
-extract configuration information from it. this will return
-the C2 address in the form "<scheme>://<ip>:<port>".
+    note: if the key passed in is NULL, a default of 'q' will be used
+    when attempting to decrypt the bytes.
+    */
+    extern char *read_cfg(char *key);
 
-the extracted bytes are decrypted and base64-decoded before
-being JSON deserialized into a configuration struct. the information
-in this struct is then used to build the string that gets
-returned by the function.
+    /*
+    function designed to read the end of the current binary and
+    extract configuration information from it. this will return
+    the C2 address in the form "<scheme>://<ip>:<port>".
 
-the type of encryption is specified by the "enc_type" argument.
-*/
-extern char *read_cfg_with_encryption(char *key, int enc_type);
+    the extracted bytes are decrypted and base64-decoded before
+    being JSON deserialized into a configuration struct. the information
+    in this struct is then used to build the string that gets
+    returned by the function.
 
-/*
-function designed to read the end of a target file and
-extract configuration information from it. this will return
-the C2 address in the form "<scheme>://<ip>:<port>".
+    the type of encryption is specified by the "enc_type" argument.
+    */
+    extern char *read_cfg_with_encryption(char *key, int enc_type);
 
-the extracted bytes are XOR-decrypted and base64-decoded before
-being JSON deserialized into a configuration struct. the information
-in this struct is then used to build the string that gets
-returned by the function.
+    /*
+    function designed to read the end of a target file and
+    extract configuration information from it. this will return
+    the C2 address in the form "<scheme>://<ip>:<port>".
 
-note: if the key passed in is NULL, a default of 'q' will be used
-when attempting to decrypt the bytes.
-*/
-extern char *read_cfg_from_file(char *filename, char *key);
+    the extracted bytes are XOR-decrypted and base64-decoded before
+    being JSON deserialized into a configuration struct. the information
+    in this struct is then used to build the string that gets
+    returned by the function.
 
-/*
-function designed to read the end of a target file and
-extract configuration information from it. this will return
-the C2 address in the form "<scheme>://<ip>:<port>".
+    note: if the key passed in is NULL, a default of 'q' will be used
+    when attempting to decrypt the bytes.
+    */
+    extern char *read_cfg_from_file(char *filename, char *key);
 
-the extracted bytes are decrypted and base64-decoded before
-being JSON deserialized into a configuration struct. the information
-in this struct is then used to build the string that gets
-returned by the function.
+    /*
+    function designed to read the end of a target file and
+    extract configuration information from it. this will return
+    the C2 address in the form "<scheme>://<ip>:<port>".
 
-the type of encryption is specified by the "enc_type" argument.
-*/
-extern char *read_cfg_from_file_with_encryption(char *filename, char *key, int enc_type);
+    the extracted bytes are decrypted and base64-decoded before
+    being JSON deserialized into a configuration struct. the information
+    in this struct is then used to build the string that gets
+    returned by the function.
 
-/*
-function designed to free memory that was originally allocated
-by rust. since the pointer was created by the rust library, the
-rust library still owns that memory and, therefore, must be freed
-by the library.
-*/
-extern void free_memory(char *ptr);
+    the type of encryption is specified by the "enc_type" argument.
+    */
+    extern char *read_cfg_from_file_with_encryption(char *filename, char *key, int enc_type);
+
+    /*
+    function designed to free memory that was originally allocated
+    by rust. since the pointer was created by the rust library, the
+    rust library still owns that memory and, therefore, must be freed
+    by the library.
+    */
+    extern void free_memory(char *ptr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __CFGPARSER_H

--- a/helpers/c/cfgparser.h
+++ b/helpers/c/cfgparser.h
@@ -43,7 +43,7 @@ extern "C"
 
     the type of encryption is specified by the "enc_type" argument.
     */
-    extern char *read_cfg_with_encryption(char *key, EncyptionType enc_type);
+    extern char *read_cfg_with_encryption(char *key, int enc_type);
 
     /*
     function designed to read the end of a target file and
@@ -72,7 +72,7 @@ extern "C"
 
     the type of encryption is specified by the "enc_type" argument.
     */
-    extern char *read_cfg_from_file_with_encryption(char *filename, char *key, EncyptionType enc_type);
+    extern char *read_cfg_from_file_with_encryption(char *filename, char *key, int enc_type);
 
     /*
     function designed to free memory that was originally allocated

--- a/helpers/c/install.sh
+++ b/helpers/c/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# this script is designed to install the cfgparser library
+# onto a linux machine and should be run as sudo or with
+# elevated permissions.
+
+BINARY_DIR=/usr/local/bin
+HEADER_DIR=/usr/local/include
+
+BINARY_FILE=./cfgparser.so
+HEADER_FILE=./cfgparser.h
+
+# step 1: copy the binary file to /usr/local/bin
+cp $BINARY_FILE $BINARY_DIR
+LASTEXITCODE=$?
+if [[ $LASTEXITCODE -ne 0 ]]; then
+    echo "[-] unable to copy shared object to $BINARY_DIR. exit code: $LASTEXITCODE" >&2
+    exit $LASTEXITCODE
+fi
+echo "[+] $BINARYFILE successfully copied to $BINARY_DIR"
+
+# step 2: copy the header file to /usr/local/include
+cp $HEADER_FILE $HEADER_DIR
+LASTEXITCODE=$?
+if [[ $LASTEXITCODE -ne 0 ]]; then
+    echo "[-] unable to copy shared object to $HEADER_DIR. exit code: $LASTEXITCODE" >&2
+    exit $LASTEXITCODE
+fi
+echo "[+] $HEADER_ILE successfully copied to $HEADER_DIR"


### PR DESCRIPTION
## Description

Added a header file (`.h` file) for C usage. 

Added `install.sh` script for linux. This will copy the `.so` file to the user's `/usr/local/bin` directory and the header file to the user's `/usr/local/include` directory.

Updated the GitHub actions YAML file to have the linux artifact include the `install.sh` file and `cfgparser.h` header file.

## Testing

Created proof of concept C program using `cfgparser.h` to confirm expected behavior.

## Associated Issues

#34 : C Header File