### PR TITLE
feat(offset): Read Bytes Offset Arg

### DIFF
--- a/cfgparser_core/src/extractor/core.rs
+++ b/cfgparser_core/src/extractor/core.rs
@@ -17,11 +17,11 @@ pub trait CfgExtractor {
 /// generic function designed to read the configuration bytes from
 /// a reader that implements the Read + Seek traits and return
 /// either a Vec<u8> or an error.
-fn read_bytes<R>(mut reader: R) -> std::io::Result<Vec<u8>>
+fn read_bytes<R>(mut reader: R, offset: usize) -> std::io::Result<Vec<u8>>
 where
     R: std::io::Read + std::io::Seek,
 {
-    let size_start: i64 = SZ_SIZEBUFF as i64 * -1;
+    let size_start: i64 = (offset + SZ_SIZEBUFF) as i64 * -1;
 
     // allocate buffer that will hold the size bytes.
     let mut buf_sz: [u8; SZ_SIZEBUFF as usize] = [0; SZ_SIZEBUFF];
@@ -59,7 +59,7 @@ impl CfgExtractor for SelfExtractor {
         let current_binary: std::path::PathBuf = std::env::current_exe()?;
         let fptr: std::fs::File = std::fs::File::open(current_binary)?;
         // read and return the  bytes from the file.
-        read_bytes(fptr)
+        read_bytes(fptr, 0)
     }
 }
 
@@ -79,7 +79,7 @@ impl FileExtractor {
 impl CfgExtractor for FileExtractor {
     fn extract_cfg_bytes(&self) -> std::io::Result<Vec<u8>> {
         let fptr: std::fs::File = std::fs::File::open(&self.filename)?;
-        read_bytes(fptr)
+        read_bytes(fptr, 0)
     }
 }
 
@@ -111,7 +111,7 @@ impl BytesExtractor {
 impl CfgExtractor for BytesExtractor {
     fn extract_cfg_bytes(&self) -> std::io::Result<Vec<u8>> {
         let stream: std::io::Cursor<&Vec<u8>> = std::io::Cursor::new(&self.stream);
-        read_bytes(stream)
+        read_bytes(stream, 0)
     }
 }
 

--- a/cfgparser_core/src/extractor/core/unit_tests.rs
+++ b/cfgparser_core/src/extractor/core/unit_tests.rs
@@ -29,7 +29,7 @@ fn test_read_bytes() -> Result<(), Box<dyn std::error::Error>> {
         59, 83, 58, 34, 40, 29, 1, 59, 51, 21, 17, 28, 57, 88, 0, 0, 0, 0, 0, 0, 0, 72,
     ]);
 
-    let result: Vec<u8> = read_bytes(test_cur)?;
+    let result: Vec<u8> = read_bytes(test_cur, 0)?;
     let result2: Vec<u8> = test_vec.extract_cfg_bytes()?;
 
     assert_eq!(result, expected);


### PR DESCRIPTION
## Description

Added an `offset` argument to `read_bytes` to specify how many bytes back the end of the size block will be found. The existing functions have had `0` added as this piece of the call to `read_bytes`.

## Testing 

Ran unit tests to confirm existing functions still working as expected.