### PR TITLE
feat(core): Read Func Offset Arg

### DIFF
--- a/cfgparser_core/src/lib.rs
+++ b/cfgparser_core/src/lib.rs
@@ -119,13 +119,13 @@ fn format_address_c(configuration: models::core::Configuration) -> *const std::f
 /// is what should be passed in as the `reader`. this struct implements
 /// logic that will read the configuration bytes from the end of
 /// the current binary.
-pub fn read<T, D>(reader: T, decryptor: D) -> CfgResult
+pub fn read<T, D>(reader: T, decryptor: D, offset: usize) -> CfgResult
 where
     T: extractor::core::CfgExtractor,
     D: cfgparser_encryption::Decryptor,
 {
     // read configuration bytes from current binary.
-    let cfg_bytes: Vec<u8> = reader.extract_cfg_bytes(0)?;
+    let cfg_bytes: Vec<u8> = reader.extract_cfg_bytes(offset)?;
 
     // decrypt and base64 decode the bytes extracted in the previous
     // step to get a string representation of the JSON structure holding
@@ -145,7 +145,7 @@ where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::SelfExtractor = extractor::core::SelfExtractor {};
-    read(reader, decryptor)
+    read(reader, decryptor, extractor::core::OFFSET_NONE)
 }
 
 /// ease-of-use function designed to call read() with a FileExtractor
@@ -155,7 +155,7 @@ where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::FileExtractor = extractor::core::FileExtractor::new(filename);
-    read(reader, decryptor)
+    read(reader, decryptor, extractor::core::OFFSET_NONE)
 }
 
 /// ease-of-use function designed to call read() with a BytesExtractor
@@ -165,7 +165,7 @@ where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::BytesExtractor = extractor::core::BytesExtractor::new(stream);
-    read(reader, decryptor)
+    read(reader, decryptor, extractor::core::OFFSET_NONE)
 }
 
 #[no_mangle]

--- a/cfgparser_core/src/lib.rs
+++ b/cfgparser_core/src/lib.rs
@@ -140,32 +140,32 @@ where
 
 /// ease-of-use function designed to call read() with a SelfExtractor
 /// and the passed in decryptor.
-pub fn read_self<D>(decryptor: D) -> CfgResult
+pub fn read_self<D>(decryptor: D, offset: usize) -> CfgResult
 where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::SelfExtractor = extractor::core::SelfExtractor {};
-    read(reader, decryptor, extractor::core::OFFSET_NONE)
+    read(reader, decryptor, offset)
 }
 
 /// ease-of-use function designed to call read() with a FileExtractor
 /// built using filename passed in and the passed in decryptor.
-pub fn read_from_file<D>(filename: String, decryptor: D) -> CfgResult
+pub fn read_from_file<D>(filename: String, decryptor: D, offset: usize) -> CfgResult
 where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::FileExtractor = extractor::core::FileExtractor::new(filename);
-    read(reader, decryptor, extractor::core::OFFSET_NONE)
+    read(reader, decryptor, offset)
 }
 
 /// ease-of-use function designed to call read() with a BytesExtractor
 /// built using the `Vec<u8>` passed in and the decryptor passed in.
-pub fn read_from_vec<D>(stream: Vec<u8>, decryptor: D) -> CfgResult
+pub fn read_from_vec<D>(stream: Vec<u8>, decryptor: D, offset: usize) -> CfgResult
 where
     D: cfgparser_encryption::Decryptor,
 {
     let reader: extractor::core::BytesExtractor = extractor::core::BytesExtractor::new(stream);
-    read(reader, decryptor, extractor::core::OFFSET_NONE)
+    read(reader, decryptor, offset)
 }
 
 #[no_mangle]
@@ -223,21 +223,21 @@ pub extern "C" fn read_cfg_with_encryption(
     if enc_type_i32 == cfgparser_encryption::EncryptionType::Xor as i32 {
         let decryptor: cfgparser_encryption::xor::engine::XORCipher =
             cfgparser_encryption::xor::engine::XORCipher::new(key.to_vec());
-        read_result = read_self(decryptor);
+        read_result = read_self(decryptor, extractor::core::OFFSET_NONE);
     } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Viginere as i32 {
         let decryptor: cfgparser_encryption::viginere::engine::ViginereCipher =
             match cfgparser_encryption::viginere::engine::ViginereCipher::new(key.to_vec()) {
                 Ok(vc) => vc,
                 Err(_) => return std::ptr::null(),
             };
-        read_result = read_self(decryptor);
+        read_result = read_self(decryptor, extractor::core::OFFSET_NONE);
     } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
         let decryptor: cfgparser_encryption::aes::engine::AESCipher =
             match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
                 Ok(aesc) => aesc,
                 Err(_) => return std::ptr::null(),
             };
-        read_result = read_self(decryptor);
+        read_result = read_self(decryptor, extractor::core::OFFSET_NONE);
     } else {
         read_result = Err("invalid encryption type".into());
     }
@@ -326,21 +326,33 @@ pub extern "C" fn read_cfg_from_file_with_encryption(
     if enc_type_i32 == cfgparser_encryption::EncryptionType::Xor as i32 {
         let decryptor: cfgparser_encryption::xor::engine::XORCipher =
             cfgparser_encryption::xor::engine::XORCipher::new(key.to_vec());
-        read_result = read_from_file(filename.to_string(), decryptor);
+        read_result = read_from_file(
+            filename.to_string(),
+            decryptor,
+            extractor::core::OFFSET_NONE,
+        );
     } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Viginere as i32 {
         let decryptor: cfgparser_encryption::viginere::engine::ViginereCipher =
             match cfgparser_encryption::viginere::engine::ViginereCipher::new(key.to_vec()) {
                 Ok(vc) => vc,
                 Err(_) => return std::ptr::null(),
             };
-        read_result = read_from_file(filename.to_string(), decryptor);
+        read_result = read_from_file(
+            filename.to_string(),
+            decryptor,
+            extractor::core::OFFSET_NONE,
+        );
     } else if enc_type_i32 == cfgparser_encryption::EncryptionType::Aes as i32 {
         let decryptor: cfgparser_encryption::aes::engine::AESCipher =
             match cfgparser_encryption::aes::engine::AESCipher::new(key.to_vec()) {
                 Ok(aesc) => aesc,
                 Err(_) => return std::ptr::null(),
             };
-        read_result = read_from_file(filename.to_string(), decryptor);
+        read_result = read_from_file(
+            filename.to_string(),
+            decryptor,
+            extractor::core::OFFSET_NONE,
+        );
     } else {
         read_result = Err("invalid encryption type".into());
     }

--- a/cfgparser_core/src/unit_tests.rs
+++ b/cfgparser_core/src/unit_tests.rs
@@ -35,7 +35,37 @@ fn test_read() -> TestResult {
 }
 
 #[test]
-/// test designed to confirm the "read()" function operates as
+/// test designed to confirm the `read()` function operates as
+/// expected when passed in an offset.
+fn test_read_offset() -> TestResult {
+    let expected: models::core::Configuration = models::core::Configuration {
+        host: "malserver".to_string(),
+        port: 9999,
+        scheme: models::core::SchemeType::HTTPS,
+    };
+
+    let reader: extractor::core::BytesExtractor = extractor::core::BytesExtractor::new(vec![
+        116, 104, 105, 115, 32, 105, 115, 32, 97, 32, 98, 117, 110, 99, 104, 32, 111, 102, 32, 106,
+        117, 110, 107, 32, 100, 97, 116, 97, 32, 116, 104, 97, 116, 32, 105, 115, 32, 103, 111,
+        105, 110, 103, 32, 116, 111, 32, 98, 101, 32, 117, 115, 101, 100, 32, 116, 111, 32, 115,
+        112, 111, 111, 102, 32, 97, 32, 102, 105, 108, 101, 22, 24, 40, 29, 7, 64, 47, 82, 59, 15,
+        28, 6, 43, 31, 84, 27, 3, 42, 60, 9, 16, 15, 56, 30, 6, 26, 40, 17, 59, 38, 57, 22, 0, 65,
+        47, 67, 40, 8, 29, 2, 60, 53, 9, 71, 42, 32, 22, 5, 59, 11, 61, 11, 3, 53, 51, 7, 59, 49,
+        59, 83, 58, 34, 40, 29, 1, 59, 51, 21, 17, 28, 57, 88, 0, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0,
+        0,
+    ]);
+
+    let key: &str = "sabre";
+    let decryptor: cfgparser_encryption::xor::engine::XORCipher =
+        cfgparser_encryption::xor::engine::XORCipher::new(key.as_bytes().to_vec());
+    let extracted: models::core::Configuration = read(reader, decryptor, 5)?;
+
+    assert_eq!(extracted, expected);
+    Ok(())
+}
+
+#[test]
+/// test designed to confirm the `read()` function operates as
 /// expected and returns the proper result when a ViginereCipher
 /// decryptor is passed to it.
 fn test_read_viginere() -> TestResult {

--- a/cfgparser_core/src/unit_tests.rs
+++ b/cfgparser_core/src/unit_tests.rs
@@ -25,7 +25,8 @@ fn test_read() -> TestResult {
         cfgparser_encryption::xor::engine::XORCipher::new(key.as_bytes().to_vec());
     let reader: extractor::core::TestExtractor = extractor::core::TestExtractor;
 
-    let extracted: models::core::Configuration = read(reader, decryptor)?;
+    let extracted: models::core::Configuration =
+        read(reader, decryptor, extractor::core::OFFSET_NONE)?;
 
     assert_eq!(extracted, expected);
     assert_ne!(extracted, unexpected);
@@ -66,15 +67,17 @@ fn test_read_viginere() -> TestResult {
     let reader2: extractor::core::BytesExtractor =
         extractor::core::BytesExtractor::new(ciphertext2);
 
-    let plaintext: models::core::Configuration = match read(reader, cipher1.clone()) {
-        Ok(result) => result,
-        Err(e) => return Err(e),
-    };
+    let plaintext: models::core::Configuration =
+        match read(reader, cipher1.clone(), extractor::core::OFFSET_NONE) {
+            Ok(result) => result,
+            Err(e) => return Err(e),
+        };
 
-    let plaintext2: models::core::Configuration = match read(reader2, cipher1) {
-        Ok(result) => result,
-        Err(e) => return Err(e),
-    };
+    let plaintext2: models::core::Configuration =
+        match read(reader2, cipher1, extractor::core::OFFSET_NONE) {
+            Ok(result) => result,
+            Err(e) => return Err(e),
+        };
 
     assert_eq!(plaintext, expected);
     assert_eq!(plaintext2, expected);
@@ -105,7 +108,8 @@ fn test_read_bytesextractor() -> TestResult {
     let key: &str = "sabre";
     let decryptor: cfgparser_encryption::xor::engine::XORCipher =
         cfgparser_encryption::xor::engine::XORCipher::new(key.as_bytes().to_vec());
-    let extracted: models::core::Configuration = read(reader, decryptor)?;
+    let extracted: models::core::Configuration =
+        read(reader, decryptor, extractor::core::OFFSET_NONE)?;
 
     assert_eq!(extracted, expected);
 

--- a/cfgparser_core/src/unit_tests.rs
+++ b/cfgparser_core/src/unit_tests.rs
@@ -71,10 +71,7 @@ fn test_read_offset() -> TestResult {
 fn test_read_viginere() -> TestResult {
     let key: Vec<u8> = b"secretkey".to_vec();
     let cipher1: cfgparser_encryption::viginere::engine::ViginereCipher =
-        match cfgparser_encryption::viginere::engine::ViginereCipher::new(key) {
-            Ok(c) => c,
-            Err(e) => return Err(e),
-        };
+        cfgparser_encryption::viginere::engine::ViginereCipher::new(key)?;
     let expected: models::core::Configuration = models::core::Configuration::new(
         "secrethost".to_string(),
         1234,

--- a/cfgparser_core/src/unit_tests.rs
+++ b/cfgparser_core/src/unit_tests.rs
@@ -93,24 +93,30 @@ fn test_read_viginere() -> TestResult {
         66, 87, 99, 79, 113, 85, 108, 83, 71, 72, 114, 67, 50, 106, 99, 102, 80, 69, 109, 77, 97,
         69, 107, 114, 76, 75, 48, 109, 71, 72, 57, 0, 0, 0, 0, 0, 0, 0, 72,
     ];
+    let ciphertext3: Vec<u8> = vec![
+        119, 99, 76, 102, 102, 51, 71, 48, 83, 110, 109, 121, 77, 112, 69, 112, 82, 51, 84, 112,
+        98, 89, 108, 120, 116, 51, 85, 98, 86, 71, 89, 97, 103, 73, 57, 112, 104, 86, 83, 54, 77,
+        66, 87, 99, 79, 113, 85, 108, 83, 71, 72, 114, 67, 50, 106, 99, 102, 80, 69, 109, 77, 97,
+        69, 107, 114, 76, 75, 48, 109, 71, 72, 57, 0, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
     let reader: extractor::core::BytesExtractor = extractor::core::BytesExtractor::new(ciphertext);
     let reader2: extractor::core::BytesExtractor =
         extractor::core::BytesExtractor::new(ciphertext2);
+    let reader3: extractor::core::BytesExtractor =
+        extractor::core::BytesExtractor::new(ciphertext3);
 
     let plaintext: models::core::Configuration =
-        match read(reader, cipher1.clone(), extractor::core::OFFSET_NONE) {
-            Ok(result) => result,
-            Err(e) => return Err(e),
-        };
+        read(reader, cipher1.clone(), extractor::core::OFFSET_NONE)?;
 
     let plaintext2: models::core::Configuration =
-        match read(reader2, cipher1, extractor::core::OFFSET_NONE) {
-            Ok(result) => result,
-            Err(e) => return Err(e),
-        };
+        read(reader2, cipher1.clone(), extractor::core::OFFSET_NONE)?;
+
+    let plaintext3: models::core::Configuration = read(reader3, cipher1, 10)?;
 
     assert_eq!(plaintext, expected);
     assert_eq!(plaintext2, expected);
+    assert_eq!(plaintext3, expected);
 
     Ok(())
 }

--- a/cfgparser_core/src/unit_tests.rs
+++ b/cfgparser_core/src/unit_tests.rs
@@ -137,7 +137,8 @@ fn test_read_from_vec() -> TestResult {
     let decryptor: cfgparser_encryption::xor::engine::XORCipher =
         cfgparser_encryption::xor::engine::XORCipher::new(key.as_bytes().to_vec());
 
-    let extracted: models::core::Configuration = read_from_vec(bytes_vec, decryptor)?;
+    let extracted: models::core::Configuration =
+        read_from_vec(bytes_vec, decryptor, extractor::core::OFFSET_NONE)?;
 
     assert_eq!(extracted, expected);
 


### PR DESCRIPTION
## Description 

This PR includes an update to the `read` function's signature to include an `offset: usize` argument that will be passed to the reader's `extract_cfg_bytes` function. This argument has also been added to the read's helper functions (eg: `read_self`, etc).

The unit tests have been updated to test the new offset functionality as well.

## Testing

Ran unit tests to confirm new functionality working and existing functionality not broken.

## Associated Issues

#52 : Update Read Signature